### PR TITLE
Feat/verification error message

### DIFF
--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -125,17 +125,17 @@ export class CertificateVerifier {
       return;
     }
 
-	  let message = getVerboseMessage(stepCode);
-    log(message);
-    this._updateCallback(stepCode, message, Status.starting);
+	  let stepName = getVerboseMessage(stepCode);
+    log(stepName);
+    this._updateCallback(stepCode, stepName, Status.starting);
 
     try {
       let res = action();
-      this._updateCallback(stepCode, message, Status.success);
+      this._updateCallback(stepCode, stepName, Status.success);
       this._stepsStatuses.push(Status.success);
       return res;
     } catch(err) {
-      this._updateCallback(stepCode, err.message, Status.failure);
+      this._updateCallback(stepCode, stepName, Status.failure, err.message);
       this._stepsStatuses.push(Status.failure);
     }
   }

--- a/verifier-es.js
+++ b/verifier-es.js
@@ -33099,17 +33099,17 @@ class CertificateVerifier {
       return;
     }
 
-	  let message = getVerboseMessage(stepCode);
-    log$4(message);
-    this._updateCallback(stepCode, message, Status.starting);
+	  let stepName = getVerboseMessage(stepCode);
+    log$4(stepName);
+    this._updateCallback(stepCode, stepName, Status.starting);
 
     try {
       let res = action();
-      this._updateCallback(stepCode, message, Status.success);
+      this._updateCallback(stepCode, stepName, Status.success);
       this._stepsStatuses.push(Status.success);
       return res;
     } catch(err) {
-      this._updateCallback(stepCode, err.message, Status.failure);
+      this._updateCallback(stepCode, stepName, Status.failure, err.message);
       this._stepsStatuses.push(Status.failure);
     }
   }

--- a/verifier-iife.js
+++ b/verifier-iife.js
@@ -32996,17 +32996,17 @@ var Verifier = (function (exports) {
 	        return;
 	      }
 
-	      var message = getVerboseMessage(stepCode);
-	      log$4(message);
-	      this._updateCallback(stepCode, message, Status.starting);
+	      var stepName = getVerboseMessage(stepCode);
+	      log$4(stepName);
+	      this._updateCallback(stepCode, stepName, Status.starting);
 
 	      try {
 	        var res = action();
-	        this._updateCallback(stepCode, message, Status.success);
+	        this._updateCallback(stepCode, stepName, Status.success);
 	        this._stepsStatuses.push(Status.success);
 	        return res;
 	      } catch (err) {
-	        this._updateCallback(stepCode, err.message, Status.failure);
+	        this._updateCallback(stepCode, stepName, Status.failure, err.message);
 	        this._stepsStatuses.push(Status.failure);
 	      }
 	    }

--- a/verifier.js
+++ b/verifier.js
@@ -33103,17 +33103,17 @@ class CertificateVerifier {
       return;
     }
 
-	  let message = getVerboseMessage(stepCode);
-    log$4(message);
-    this._updateCallback(stepCode, message, Status.starting);
+	  let stepName = getVerboseMessage(stepCode);
+    log$4(stepName);
+    this._updateCallback(stepCode, stepName, Status.starting);
 
     try {
       let res = action();
-      this._updateCallback(stepCode, message, Status.success);
+      this._updateCallback(stepCode, stepName, Status.success);
       this._stepsStatuses.push(Status.success);
       return res;
     } catch(err) {
-      this._updateCallback(stepCode, err.message, Status.failure);
+      this._updateCallback(stepCode, stepName, Status.failure, err.message);
       this._stepsStatuses.push(Status.failure);
     }
   }


### PR DESCRIPTION
before the error message is being returned in lieu of the stepName, which makes the consumer need to decide locally the name of the failing step and the error message associated with it.

This new design, a breaking change, enables a clear separation of concerns.