### PR TITLE
Fix/i18n final step

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This will run the verification of a certificate. The function is asynchronous.
 const certificateVerification = await certificate.verify(({code, label, status, errorMessage}) => {
     console.log('Sub step update:', code, label, status);
 }));
-console.log(`Verification was a ${certificateVerification.status}:`, certificateVerification.errorMessage);
+console.log(`Verification was a ${certificateVerification.status}:`, certificateVerification.message);
 ```
 
 #### Parameters
@@ -166,11 +166,18 @@ console.log(`Verification was a ${certificateVerification.status}:`, certificate
 #### Returns
 The final verification status:
 ```javascript
-{ code, status, errorMessage }
+{ code, status, message }
 ```
 - `code`: code of the final step (`final`)
 - `status`: final verification status (`success`, `failure`)
-- `errorMessage`: error message (optional)
+- `message` string | Object: status message. It is internationalized in case of success, in case of failure it returns the error message of the failed step. When an object, it takes the following shape:
+  - `mocknet` Object: case of a test issuance (`mocknet`, `regtest`)
+  - `blockchain` Object: case of an actual issuance. For now `testnet` is also considered an actual issuance, TBC.
+    - `label`: Main label of the final step
+    - `description`: further details about the issuance
+    - `linkText`: translation provided for a link text towards the transaction
+
+Shape of the returned object can be checked here: https://github.com/blockchain-certificates/cert-verifier-js/blob/master/src/data/i18n.json#L41
 
 ### Constants
 Several constants are being exposed:

--- a/README.md
+++ b/README.md
@@ -170,12 +170,10 @@ The final verification status:
 ```
 - `code`: code of the final step (`final`)
 - `status`: final verification status (`success`, `failure`)
-- `message` string | Object: status message. It is internationalized in case of success, in case of failure it returns the error message of the failed step. When an object, it takes the following shape:
-  - `mocknet` Object: case of a test issuance (`mocknet`, `regtest`)
-  - `blockchain` Object: case of an actual issuance. For now `testnet` is also considered an actual issuance, TBC.
-    - `label`: Main label of the final step
-    - `description`: further details about the issuance
-    - `linkText`: translation provided for a link text towards the transaction
+- `message` string | Object: status message. It is internationalized and in case of failure it returns the error message of the failed step. When an object, it takes the following shape:
+  - `label`: Main label of the final step
+  - `description`: further details about the issuance
+  - `linkText`: translation provided for a link text towards the transaction
 
 Shape of the returned object can be checked here: https://github.com/blockchain-certificates/cert-verifier-js/blob/master/src/data/i18n.json#L41
 

--- a/src/constants/blockchains.js
+++ b/src/constants/blockchains.js
@@ -53,7 +53,6 @@ export const BLOCKCHAINS = {
   testnet: {
     code: 'testnet',
     name: 'Mocknet',
-    test: true,
     signatureValue: 'bitcoinTestnet',
     transactionTemplates: {
       full: `https://testnet.blockchain.info/tx/${TRANSACTION_TEMPLATE_ID_PLACEHOLDER}`,

--- a/src/constants/blockchains.js
+++ b/src/constants/blockchains.js
@@ -33,6 +33,7 @@ export const BLOCKCHAINS = {
   mocknet: {
     code: 'mocknet',
     name: 'Mocknet',
+    test: true,
     signatureValue: 'mockchain',
     transactionTemplates: {
       full: '',
@@ -42,6 +43,7 @@ export const BLOCKCHAINS = {
   regtest: {
     code: 'regtest',
     name: 'Mocknet',
+    test: true,
     signatureValue: 'bitcoinRegtest',
     transactionTemplates: {
       full: '',
@@ -51,6 +53,7 @@ export const BLOCKCHAINS = {
   testnet: {
     code: 'testnet',
     name: 'Mocknet',
+    test: true,
     signatureValue: 'bitcoinTestnet',
     transactionTemplates: {
       full: `https://testnet.blockchain.info/tx/${TRANSACTION_TEMPLATE_ID_PLACEHOLDER}`,

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -200,13 +200,13 @@
     },
     "success": {
       "mocknet": {
-        "label": "This Mocknet credential passed all checks",
-        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+        "label": "Esta credencial de Mocknet pasó todas las comprobaciones",
+        "description": "Las credenciales de Mocknet se usan solo con fines de prueba. No se graban en una cadena de bloques, y no se deben considerar Blockcerts Verificados."
       },
       "blockchain": {
-        "label": "Verified",
-        "description": "This is a valid ${chain} certificate.",
-        "linkText": "View transaction link"
+        "label": "Verificado",
+        "description": "Este es un certificado válido de ${chain}.",
+        "linkText": "Ver enlace de transacción"
       }
     },
     "errors": {

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -280,13 +280,13 @@
     },
     "success": {
       "mocknet": {
-        "label": "This Mocknet credential passed all checks",
-        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+        "label": "Din il-kredenzjali tal-Mocknet għaddiet il-kontrolli kollha",
+        "description": "Il-kredenzjali tal-Mocknet jintużaw biss għal skopijiet ta 'ttestjar. Dawn mhumiex irreġistrati fuq blockchain, u ma għandhomx jiġu kkunsidrati bħala blockcerts verifikati."
       },
       "blockchain": {
-        "label": "Verified",
-        "description": "This is a valid ${chain} certificate.",
-        "linkText": "View transaction link"
+        "label": "Ivverifikat",
+        "description": "Dan huwa ċertifikat ${chain} huwa validu.",
+        "linkText": "Ara l-link tat-transazzjoni"
       }
     },
     "errors": {

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -39,8 +39,15 @@
       "reason": "This certificate has been revoked by the issuer."
     },
     "success": {
-      "mocknet": "This mock Blockcert passed all checks. Mocknet mode is only used for issuers to test their workflow locally. This Blockcert was not recorded on a blockchain, and it should not be considered a verified Blockcert.",
-      "blockchain": "Success"
+      "mocknet": {
+        "label": "This Mocknet credential passed all checks",
+        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+      },
+      "blockchain": {
+        "label": "Verified",
+        "description": "This is a valid ${chain} certificate.",
+        "linkText": "View transaction link"
+      }
     },
     "errors": {
       "certificateNotValid": "This is not a valid certificate",

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -125,7 +125,7 @@
       },
       "blockchain": {
         "label": "Vérifié",
-        "description": "Ceci est un certificat ${chain} valid.",
+        "description": "Ceci est un certificat ${chain} valide.",
         "linkText": "Voir la transaction"
       }
     },

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -199,8 +199,15 @@
       "reason": "Este certificado ha sido revocado por el emisor"
     },
     "success": {
-      "mocknet": "Este Blockcert de prueba pasó todas los controles. El modo Mocknet es utilizado solamente para que los emisores prueben su flujo de trabajo localmente",
-      "blockchain": "Éxito"
+      "mocknet": {
+        "label": "This Mocknet credential passed all checks",
+        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+      },
+      "blockchain": {
+        "label": "Verified",
+        "description": "This is a valid ${chain} certificate.",
+        "linkText": "View transaction link"
+      }
     },
     "errors": {
       "certificateNotValid": "Este no es un certificado válido",
@@ -272,8 +279,15 @@
       "reason": "Dan iċ-ċertifikat ġie revokat mill-emittent."
     },
     "success": {
-      "mocknet": "Dan il-mock Blockcert għadda mill-verifiki kollha. Il-Mocknet mode jintuża biss sabiex l-emittenti jittestjaw il-workflow lokalment.",
-      "blockchain": "Suċċess"
+      "mocknet": {
+        "label": "This Mocknet credential passed all checks",
+        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+      },
+      "blockchain": {
+        "label": "Verified",
+        "description": "This is a valid ${chain} certificate.",
+        "linkText": "View transaction link"
+      }
     },
     "errors": {
       "certificateNotValid": "Dan mhux ċertifikat validu",
@@ -345,8 +359,15 @@
       "reason": "Questo certificato è stato revocato dall'emittente."
     },
     "success": {
-      "mocknet": "Questo Blockcert simulato ha superato tutti i controlli. La modalità Mocknet è utilizzata solo dagli emittenti per testare il loro flusso di lavoro localmente. Questo Blockcert non è stato registrato su una blockchain e non dovrebbe essere considerato un Blockcert verificato.",
-      "blockchain": "Successo"
+      "mocknet": {
+        "label": "This Mocknet credential passed all checks",
+        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+      },
+      "blockchain": {
+        "label": "Verified",
+        "description": "This is a valid ${chain} certificate.",
+        "linkText": "View transaction link"
+      }
     },
     "errors": {
       "certificateNotValid": "Questo non è un certificato valido",
@@ -418,8 +439,15 @@
       "reason": "この証明書は発行者によって取り消されました。"
     },
     "success": {
-      "mocknet": "この模擬Blockcertは全てのチェックを通過しました。Mocknetモードは発行者がローカル環境でワークフローを確認するためのものです。このBlockcertはブロックチェーンに記録されていなく、認証済みのBlockcertとして扱われません。",
-      "blockchain": "成功"
+      "mocknet": {
+        "label": "This Mocknet credential passed all checks",
+        "description": "Mocknet credentials are used for test purposes only. They are not recorded on a blockchain, and they should not be considered verified Blockcerts."
+      },
+      "blockchain": {
+        "label": "Verified",
+        "description": "This is a valid ${chain} certificate.",
+        "linkText": "View transaction link"
+      }
     },
     "errors": {
       "certificateNotValid": "この証明書は有効ではありません",

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -159,7 +159,7 @@
       "isTransactionIdValid": "Impossible de vérifier ce certificat sans un identifiant de transaction valide"
     }
   },
-  "es-ES": {
+  "es": {
     "steps": {
       "formatValidationLabel": "Validación de formato",
       "formatValidationLabelPending": "Validando el formato",

--- a/src/data/i18n.json
+++ b/src/data/i18n.json
@@ -119,8 +119,15 @@
       "reason": "Ce certificat a été révoqué par l'émetteur."
     },
     "success": {
-      "mocknet": "Ce Blockcert de test a été vérifié. Le mode Mocknet est utilisé uniquement par les émetteurs afin de tester leur pré-émission. Ce Blockcert n'a pas été enregistré sur une blockchain, et en tant que tel ne peut pas être considéré un Blockcert valide.",
-      "blockchain": "Valide"
+      "mocknet": {
+        "label": "Cet enregistrement Mocknet a été vérifié",
+        "description": "Le mode Mocknet est utilisé à des fins de tests uniquement. Ce Blockcert n'a pas été enregistré sur une blockchain, et en tant que tel ne peut pas être considéré un Blockcert valide."
+      },
+      "blockchain": {
+        "label": "Vérifié",
+        "description": "Ceci est un certificat ${chain} valid.",
+        "linkText": "Voir la transaction"
+      }
     },
     "errors": {
       "certificateNotValid": "Certificat invalide",

--- a/src/domain/chains/useCases/isMockChain.js
+++ b/src/domain/chains/useCases/isMockChain.js
@@ -3,13 +3,13 @@ import { BLOCKCHAINS } from '../../../constants';
 export default function isMockChain (chain) {
   if (chain) {
     const chainCode = typeof chain === 'string' ? chain : chain.code;
-    const isChainValid = Object.keys(BLOCKCHAINS).find(chainObj => chainObj === chainCode);
+    const isChainValid = Object.keys(BLOCKCHAINS).some(chainObj => chainObj === chainCode);
 
     if (!isChainValid) {
       return null;
     }
 
-    return chainCode === BLOCKCHAINS.mocknet.code || chainCode === BLOCKCHAINS.regtest.code;
+    return !!BLOCKCHAINS[chainCode].test;
   }
 
   return null;

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -278,11 +278,15 @@ export default class Verifier {
    * Returns a final success message
    */
   _succeed () {
-    const logMessage = domain.chains.isMockChain(this.chain)
+    const message = domain.chains.isMockChain(this.chain)
       ? domain.i18n.getText('success', 'mocknet')
       : domain.i18n.getText('success', 'blockchain');
-    log(logMessage);
-    return { code: STEPS.final, status: VERIFICATION_STATUSES.SUCCESS };
+    log(message);
+    return this._setFinalStep({ status: VERIFICATION_STATUSES.SUCCESS, message });
+  }
+
+  _setFinalStep ({ status, message }) {
+    return { code: STEPS.final, status, message };
   }
 
   /**

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -53,7 +53,7 @@ export default class Verifier {
 
     // Send final callback update for global verification status
     const erroredStep = this._stepsStatuses.find(step => step.status === VERIFICATION_STATUSES.FAILURE);
-    return erroredStep ? this._failed(erroredStep.message) : this._succeed();
+    return erroredStep ? this._failed(erroredStep) : this._succeed();
   }
 
   /**
@@ -255,9 +255,10 @@ export default class Verifier {
    * @returns {{code: string, status: string, errorMessage: *}}
    * @private
    */
-  _failed (errorMessage) {
-    log(`failure:${errorMessage}`);
-    return { code: STEPS.final, status: VERIFICATION_STATUSES.FAILURE, errorMessage };
+  _failed (errorStep) {
+    const message = errorStep.errorMessage;
+    log(`failure:${message}`);
+    return this._setFinalStep({ status: VERIFICATION_STATUSES.FAILURE, message });
   }
 
   /**

--- a/test/application/certificate/certificate.test.js
+++ b/test/application/certificate/certificate.test.js
@@ -73,7 +73,7 @@ describe('Certificate entity test suite', function () {
 
     describe('given locale option is passed', function () {
       let instance;
-      const fixtureOptions = { locale: 'es-ES' };
+      const fixtureOptions = { locale: 'es' };
       const fixtureInvalidLocaleOptions = { locale: 'az-az' };
 
       afterEach(function () {

--- a/test/application/certificate/verify.test.js
+++ b/test/application/certificate/verify.test.js
@@ -40,13 +40,10 @@ describe('Certificate test suite', function () {
       });
 
       describe('when the certificate is invalid', function () {
-        it.only('should call it with the step, the text, the status & the error message', async function () {
-          const updates = [];
-          const certificate = new Certificate(FIXTURES.MainnetV2Revoked);
-          await certificate.verify(update => {
-            updates.push(update);
-          });
+        let certificate;
 
+        it('should call it with the step, the text, the status & the error message', async function () {
+          let updates = [];
           let assertionStep = {
             code: SUB_STEPS.checkRevokedStatus,
             label: SUB_STEPS.language.checkRevokedStatus.labelPending,
@@ -54,7 +51,13 @@ describe('Certificate test suite', function () {
             errorMessage: 'This certificate has been revoked by the issuer. Reason given: Issued in error.'
           };
 
-          const comparisonStep = updates.find(update => update.code === SUB_STEPS.checkRevokedStatus);
+          certificate = new Certificate(FIXTURES.MainnetV2Revoked);
+
+          await certificate.verify(update => {
+            updates.push(update);
+          });
+
+          const comparisonStep = updates.find(update => update.code === SUB_STEPS.checkRevokedStatus && update.status === VERIFICATION_STATUSES.FAILURE);
           expect(comparisonStep).toEqual(assertionStep);
         });
       });

--- a/test/application/certificate/verify.test.js
+++ b/test/application/certificate/verify.test.js
@@ -1,6 +1,7 @@
 import { Certificate, STEPS, SUB_STEPS, VERIFICATION_STATUSES } from '../../../src';
 import sinon from 'sinon';
 import FIXTURES from '../../fixtures';
+import domain from '../../../src/domain';
 
 describe('Certificate test suite', function () {
   describe('verify method', function () {
@@ -29,9 +30,11 @@ describe('Certificate test suite', function () {
         });
 
         it('should return the success finalStep', async function () {
+          const successMessage = domain.i18n.getText('success', 'blockchain');
           const expectedFinalStep = {
             code: STEPS.final,
-            status: VERIFICATION_STATUSES.SUCCESS
+            status: VERIFICATION_STATUSES.SUCCESS,
+            message: successMessage
           };
 
           const finalStep = await certificate.verify();

--- a/test/application/certificate/verify.test.js
+++ b/test/application/certificate/verify.test.js
@@ -63,6 +63,17 @@ describe('Certificate test suite', function () {
           const comparisonStep = updates.find(update => update.code === SUB_STEPS.checkRevokedStatus && update.status === VERIFICATION_STATUSES.FAILURE);
           expect(comparisonStep).toEqual(assertionStep);
         });
+
+        it('should return the failure finalStep', async function () {
+          const expectedFinalStep = {
+            code: STEPS.final,
+            status: VERIFICATION_STATUSES.FAILURE,
+            message: 'This certificate has been revoked by the issuer. Reason given: Issued in error.'
+          };
+
+          const finalStep = await certificate.verify();
+          expect(finalStep).toEqual(expectedFinalStep);
+        });
       });
     });
   });

--- a/test/application/domain/chains/useCases/isMockChain.test.js
+++ b/test/application/domain/chains/useCases/isMockChain.test.js
@@ -20,10 +20,28 @@ describe('domain chains isMockChain use case test suite', function () {
     });
 
     describe('given the chain is passed as an object and is a valid test chain', function () {
-      it('should return true', function () {
-        const assertionTestChain = BLOCKCHAINS.mocknet;
-        const result = domain.chains.isMockChain(assertionTestChain);
-        expect(result).toBe(true);
+      describe('given the chain is Mocknet', function () {
+        it('should return true', function () {
+          const assertionTestChain = BLOCKCHAINS.mocknet;
+          const result = domain.chains.isMockChain(assertionTestChain);
+          expect(result).toBe(true);
+        });
+      });
+
+      describe('given the chain is Testnet', function () {
+        it('should return true', function () {
+          const assertionTestChain = BLOCKCHAINS.testnet;
+          const result = domain.chains.isMockChain(assertionTestChain);
+          expect(result).toBe(true);
+        });
+      });
+
+      describe('given the chain is Regtest', function () {
+        it('should return true', function () {
+          const assertionTestChain = BLOCKCHAINS.regtest;
+          const result = domain.chains.isMockChain(assertionTestChain);
+          expect(result).toBe(true);
+        });
       });
     });
 

--- a/test/application/domain/chains/useCases/isMockChain.test.js
+++ b/test/application/domain/chains/useCases/isMockChain.test.js
@@ -29,10 +29,10 @@ describe('domain chains isMockChain use case test suite', function () {
       });
 
       describe('given the chain is Testnet', function () {
-        it('should return true', function () {
+        it('should return false', function () {
           const assertionTestChain = BLOCKCHAINS.testnet;
           const result = domain.chains.isMockChain(assertionTestChain);
-          expect(result).toBe(true);
+          expect(result).toBe(false);
         });
       });
 

--- a/test/application/domain/i18n/useCases/getSupportedLanguages.test.js
+++ b/test/application/domain/i18n/useCases/getSupportedLanguages.test.js
@@ -1,7 +1,7 @@
 import domain from '../../../../../src/domain';
 
 describe('domain i18n getSupportedLanguages use case test suite', () => {
-  const assertionSupportedLanguages = ['en-US', 'fr', 'es-ES', 'mt', 'it-IT', 'ja'];
+  const assertionSupportedLanguages = ['en-US', 'fr', 'es', 'mt', 'it-IT', 'ja'];
 
   it('should return an array of supported languages', () => {
     const res = domain.i18n.getSupportedLanguages();

--- a/test/e2e/i18n.test.js
+++ b/test/e2e/i18n.test.js
@@ -4,10 +4,10 @@ import assertionSpanishVerificationSteps from '../assertions/assertion-spanish-v
 
 describe('End-to-end i18n test suite', function () {
   describe('given the language is set to spanish', () => {
-    const certificate = new Certificate(FIXTURES.MainnetV2Valid, { locale: 'es-ES' });
+    const certificate = new Certificate(FIXTURES.MainnetV2Valid, { locale: 'es' });
 
-    it('should set the locale to es-ES', async function () {
-      expect(certificate.locale).toBe('es-ES');
+    it('should set the locale to es', async function () {
+      expect(certificate.locale).toBe('es');
     });
 
     it('should have the verification steps in spanish', async function () {

--- a/test/e2e/verifier.test.js
+++ b/test/e2e/verifier.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 import { Certificate, SUB_STEPS, VERIFICATION_STATUSES } from '../../src';
 import FIXTURES from '../fixtures';
 

--- a/test/e2e/verifier.test.js
+++ b/test/e2e/verifier.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { Certificate, SUB_STEPS, VERIFICATION_STATUSES } from '../../src';
 import FIXTURES from '../fixtures';
 


### PR DESCRIPTION
### Summary
Final step was hardcoded in Blockcerts Verifier, and cert-verifier-js was anyway not sending this piece of information, which rendered translations useless for the final step (plus any verification would always be concluded in English).

@akodate, @dariomas could you please provide translations for the missing bits in Japanese and Italian? Thanks a million.
