### PR TITLE
fix(error): VerifierError constructor missed first argument

### DIFF
--- a/src/explorers/bitcoin.js
+++ b/src/explorers/bitcoin.js
@@ -60,7 +60,7 @@ export function getChainSoFetcher (transactionId, chain) {
 
 function parseBlockCypherResponse (jsonResponse) {
   if (jsonResponse.confirmations < CONFIG.MininumConfirmations) {
-    throw new VerifierError(getText('errors', 'parseBlockCypherResponse'));
+    throw new VerifierError(SUB_STEPS.fetchRemoteHash, getText('errors', 'parseBlockCypherResponse'));
   }
   const time = dateToUnixTimestamp(jsonResponse.received);
   const outputs = jsonResponse.outputs;
@@ -80,7 +80,7 @@ function parseBlockCypherResponse (jsonResponse) {
 
 function parseChainSoResponse (jsonResponse) {
   if (jsonResponse.data.confirmations < CONFIG.MininumConfirmations) {
-    throw new VerifierError(getText('errors', 'parseChainSoResponse'));
+    throw new VerifierError(SUB_STEPS.fetchRemoteHash, getText('errors', 'parseChainSoResponse'));
   }
   const time = new Date(jsonResponse.data.time * 1000);
   const outputs = jsonResponse.data.outputs;


### PR DESCRIPTION
### Summary

File [`bitcoin.js`][bitcoin.js] was creating `VerifierError` instances without
the first argument present.

[bitcoin.js]: https://github.com/blockchain-certificates/cert-verifier-js/blob/c2679d51d04bcb71e355934030097c771640219d/src/explorers/bitcoin.js