### PR TITLE
doc(README.md): API wrong types

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ The certificate instance has the following properties:
 - `metadataJson`: `Object`. Certificate metadata object
 - `name`: `String`. Name of the certificate
 - `publicKey`: `String`. Certificate's public key
-- `receipt`: `String`. Certificate's receipt
+- `receipt`: `Object`. Certificate's receipt
 - `recipientFullName`: `String`. Full name of recipient
 - `recordLink`: `String`. Link to the certificate record
 - `revocationKey`: `String|null`. Revocation key (if any)
 - `sealImage`: `String`. Raw data of the seal's image;
-- `signature`: `String`. Certificate's signature
+- `signature`: `String|null`. Certificate's signature
 - `signatureImage`: [`SignatureImage[]`][signatureLineModel]. Array of certificate [signature lines][signatureLineModel].
-- `subtitle`: `String`. Subtitle of the certificate
+- `subtitle`: `String|null`. Subtitle of the certificate
 - `transactionId`: `String`. Transaction ID
 - `rawTransactionLink`: `String`. Raw transaction ID
 - `transactionLink`: `String`. Transaction link

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The certificate instance has the following properties:
 - `certificateJson`: `Object`. Certificate JSON object
 - `chain`: `Object`. Chain the certificate was issued on
 - `description`: `String`. Description of the certificate
-- `expires`: `String`. Expiration date
+- `expires`: `String|null`. Expiration date
 - `id`: `String`. Certificate's ID
 - `isFormatValid`: `Boolean`. Indicates whether or not the certificate has a valid format
 - `issuedOn`: `String`. Datetime of issuance (ISO-8601)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The certificate instance has the following properties:
 - `issuedOn`: `String`. Datetime of issuance (ISO-8601)
 - `issuer`: `Object`. Certificate issuer
 - `locale`: `String`. Language code used by the verifier
-- `metadataJson`: `Object`. Certificate metadata object
+- `metadataJson`: `Object|null `. Certificate metadata object
 - `name`: `String`. Name of the certificate
 - `publicKey`: `String`. Certificate's public key
 - `receipt`: `Object`. Certificate's receipt


### PR DESCRIPTION
Those API fields also contain wrong types:

- `receipt`: It's an `Object`, as per the standards and [v1](https://github.com/blockchain-certificates/cert-verifier-js/blob/30a7faed8dfce1cfd473878437862583216d687b/src/parser.js#L56), [v2](https://github.com/blockchain-certificates/cert-verifier-js/blob/30a7faed8dfce1cfd473878437862583216d687b/src/parser.js#L109)

- `signature`. [It is null on Blockerts v2](https://github.com/blockchain-certificates/cert-verifier-js/blob/30a7faed8dfce1cfd473878437862583216d687b/src/parser.js#L141)

- `subtitle`. No [mandatory standard field `subtitle`](https://github.com/blockchain-certificates/cert-schema/blob/master/cert_schema/2.1/schema.json#L187-L256) on Blockcerts v2 badges, so can be null.

- `expires`. As [specified per the standard](https://github.com/blockchain-certificates/cert-schema/blob/master/cert_schema/2.1/schema.json#L316-L323), can be `null`

- `metadataJson`. As [specified per the standard](https://github.com/blockchain-certificates/cert-schema/blob/master/cert_schema/2.1/schema.json#L316-L323), can be `null`