### PR TITLE
fix(Verify): Add Etherscan api key to allow eth verifications #422

### DIFF
--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -8,6 +8,8 @@ const TRANSACTION_APIS = {
 
 const TRANSACTION_ID_PLACEHOLDER = '{transaction_id}';
 
+const ETHERSCAN_API_KEY = 'FJ3CZWH8PQBV8W5U6JR8TMKAYDHBKQ3B1D';
+
 const TRANSACTIONS_APIS_URLS = {
   [TRANSACTION_APIS.Bitpay]: {
     mainnet: `https://insight.bitpay.com/api/tx/${TRANSACTION_ID_PLACEHOLDER}`,
@@ -27,8 +29,8 @@ const TRANSACTIONS_APIS_URLS = {
   },
   // Add &apikey={key} to EtherScan URL's if getting rate limited
   [TRANSACTION_APIS.Etherscan]: {
-    main: 'https://api.etherscan.io/api?module=proxy',
-    ropsten: 'https://api-ropsten.etherscan.io/api?module=proxy'
+    main: `https://api.etherscan.io/api?module=proxy&apikey=${ETHERSCAN_API_KEY}`,
+    ropsten: `https://api-ropsten.etherscan.io/api?module=proxy&apikey=${ETHERSCAN_API_KEY}`
   }
 };
 


### PR DESCRIPTION
### Summary

Due to #422 ETH verifications are not working. This is a temporary measure to fix it. Long term we need to find a way to hide the API key while still letting it be a library for some of our other open source (like BUV & mobile apps). We also need to add a few ethereum backup API's - those are long overdue. 

It's less concerning exposing this API key since it's a free key and anyone can register for one. 
