### PR TITLE
fix(Node): make babel runtime a production dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2496,7 +2496,6 @@
       "version": "7.8.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
       "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -16567,10 +16566,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
-      "dev": true
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": "^7.8.7",
     "@vaultie/lds-merkle-proof-2019": "0.0.6",
     "bigi": "^1.4.2",
     "bitcoinjs-lib": "^5.0.3",
@@ -71,7 +72,6 @@
     "@babel/core": "^7.8.7",
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
-    "@babel/runtime": "^7.4.4",
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
     "brfs": "^2.0.2",


### PR DESCRIPTION
Was not caught before release as likely available when using `npm link`