### PR TITLE
fix(ExplorerAPIs): [#548] throw error early when overwriting explorer is malformed

### DIFF
--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -17,6 +17,14 @@ export interface TDefaultExplorersPerBlockchain {
 function cleanupExplorerAPIs (explorerAPIs: ExplorerAPI[], indexes: number[]): void {
   indexes.forEach(index => explorerAPIs.splice(index, 1)); // remove modified explorer to avoid setting them in the custom option later
 }
+
+function validateOverwritingExplorer (explorerAPI: ExplorerAPI): boolean {
+  if (explorerAPI.key && !explorerAPI.keyPropertyName) {
+    throw new Error(`Property keyPropertyName is not set for ${explorerAPI.serviceName}. Cannot pass the key property to the service.`);
+  }
+  return true;
+}
+
 const overwrittenIndexes: number[] = [];
 
 export function overwriteDefaultExplorers (explorerAPIs: ExplorerAPI[] = [], defaultExplorers: ExplorerAPI[] = [], lastSetOfExplorers = false): ExplorerAPI[] {
@@ -30,11 +38,13 @@ export function overwriteDefaultExplorers (explorerAPIs: ExplorerAPI[] = [], def
       if (userSetExplorerAPIsName.includes(defaultExplorerAPI.serviceName)) {
         const immutableExplorerAPI = Object.assign({}, defaultExplorerAPI);
         const customSetExplorerAPI = explorerAPIs.find(customExplorerAPI => customExplorerAPI.serviceName === defaultExplorerAPI.serviceName);
-        const overwrittenExplorerAPI = Object.assign(immutableExplorerAPI, customSetExplorerAPI);
-        overwrittenExplorers.push(overwrittenExplorerAPI);
-        const explorerAPIsIndex = explorerAPIs.findIndex(explorerAPI => explorerAPI.serviceName === overwrittenExplorerAPI.serviceName);
-        if (!overwrittenIndexes.includes(explorerAPIsIndex)) {
-          overwrittenIndexes.push(explorerAPIsIndex);
+        if (validateOverwritingExplorer(customSetExplorerAPI)) {
+          const overwrittenExplorerAPI = Object.assign(immutableExplorerAPI, customSetExplorerAPI);
+          overwrittenExplorers.push(overwrittenExplorerAPI);
+          const explorerAPIsIndex = explorerAPIs.findIndex(explorerAPI => explorerAPI.serviceName === overwrittenExplorerAPI.serviceName);
+          if (!overwrittenIndexes.includes(explorerAPIsIndex)) {
+            overwrittenIndexes.push(explorerAPIsIndex);
+          }
         }
       } else {
         overwrittenExplorers.push(defaultExplorerAPI);

--- a/test/application/explorers/explorer.test.ts
+++ b/test/application/explorers/explorer.test.ts
@@ -83,6 +83,21 @@ describe('Blockchain Explorers test suite', function () {
         const expectedOutput = [Object.assign(mockDefaultExplorer, fixtureExplorer), BlockcypherAPI];
         expect(output).toEqual(expectedOutput);
       });
+
+      describe('and the explorer overwrite is malformed', function () {
+        describe('when a key is set but no keyPropertyName', function () {
+          it('should throw an error', function () {
+            const fixtureExplorer: ExplorerAPI = {
+              serviceName: TRANSACTION_APIS.bitpay,
+              key: 'a-custom-key'
+            };
+
+            expect(() => {
+              overwriteDefaultExplorers([fixtureExplorer], [BitpayAPI, BlockcypherAPI]);
+            }).toThrow('Property keyPropertyName is not set for bitpay. Cannot pass the key property to the service.');
+          });
+        });
+      });
     });
 
     describe('given it was passed no default explorer match', function () {


### PR DESCRIPTION
A small improvement to help with development consumption