### PR TITLE
fix(ExplorerApis): [#667] pass deep copy to viewer

### DIFF
--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -8,6 +8,7 @@ import { TExplorerParsingFunction } from './explorers/explorer';
 import { IBlockchainObject } from './constants/blockchains';
 import Versions from './constants/certificateVersions';
 import { TRANSACTION_APIS } from './constants/api';
+import { deepCopy } from './helpers/object';
 
 export interface ExplorerURLs {
   main: string;
@@ -71,7 +72,7 @@ export default class Certificate {
     }
 
     // Keep certificate JSON object
-    this.certificateJson = JSON.parse(JSON.stringify(certificateDefinition));
+    this.certificateJson = deepCopy<Blockcerts>(certificateDefinition);
   }
 
   async init (): Promise<void> {
@@ -98,7 +99,7 @@ export default class Certificate {
       revocationKey: this.revocationKey,
       transactionId: this.transactionId,
       version: this.version,
-      explorerAPIs: this.explorerAPIs
+      explorerAPIs: deepCopy<ExplorerAPI[]>(this.explorerAPIs)
     });
     return await verifier.verify(stepCallback);
   }

--- a/src/domain/certificates/useCases/getVerificationMap.js
+++ b/src/domain/certificates/useCases/getVerificationMap.js
@@ -3,6 +3,7 @@ import chainsService from '../../chains';
 import { getText } from '../../i18n/useCases';
 import { isV3 } from '../../../constants/certificateVersions';
 import { getIssuerProfile } from '../../../constants/verificationSubSteps';
+import { deepCopy } from '../../../helpers/object';
 
 const versionVerificationMap = {
   [NETWORKS.mainnet]: [
@@ -54,7 +55,7 @@ function stepsObjectToArray (stepsObject) {
  * @returns {any}
  */
 function setSubStepsToSteps (subSteps) {
-  const steps = JSON.parse(JSON.stringify(STEPS.language));
+  const steps = deepCopy(STEPS.language);
   subSteps.forEach(subStep => steps[subStep.parentStep].subSteps.push(subStep));
   return steps;
 }

--- a/src/helpers/object.ts
+++ b/src/helpers/object.ts
@@ -1,0 +1,3 @@
+export function deepCopy<T = any> (obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/application/helpers/object.test.ts
+++ b/test/application/helpers/object.test.ts
@@ -1,0 +1,11 @@
+import { deepCopy } from '../../../src/helpers/object';
+
+describe('deepCopy method', function () {
+  it('should return false', function () {
+    const fixtureObject = { key: 'value' };
+    const fixtureObjectDeepCopy = { key: 'value' };
+    const result = deepCopy<object>(fixtureObject);
+    fixtureObject.key = 'updated value';
+    expect(result).toEqual(fixtureObjectDeepCopy);
+  });
+});

--- a/test/application/verifier/verifier.test.ts
+++ b/test/application/verifier/verifier.test.ts
@@ -30,6 +30,9 @@ describe('Verifier entity test suite', function () {
   });
 
   describe('constructor method', function () {
+    /* eslint @typescript-eslint/no-unused-vars: "off" */
+    let instance;
+
     beforeEach(function () {
       verifierInstance = new Verifier(verifierParamFixture);
     });
@@ -95,7 +98,7 @@ describe('Verifier entity test suite', function () {
               expectedExplorers.custom = explorerFactory(fixtureExplorerAPI);
 
               expect(() => {
-                const instance = new Verifier(fixture);
+                instance = new Verifier(fixture);
               }).toThrow('One or more of your custom explorer APIs has a priority set below zero');
             });
           });
@@ -113,7 +116,7 @@ describe('Verifier entity test suite', function () {
               expectedExplorers.custom = explorerFactory(fixtureExplorerAPI);
 
               expect(() => {
-                const instance = new Verifier(fixture);
+                instance = new Verifier(fixture);
               }).toThrow('One or more of your custom explorer APIs does not have a parsing function');
             });
           });


### PR DESCRIPTION
### Summary
- Fix for #667
The `explorerAPIs` reference was copied to the viewer, not its value. A deep copy did the trick. `ExplorerAPIs` are now used on all verification processes, not just the first one.

- Also refactored code to add a `deepCopy` helper
