### PR TITLE
feat(PublicKey): retrieve public key from transaction data as source of truth

### DIFF
--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -102,7 +102,9 @@ export default class Certificate {
       version: this.version,
       explorerAPIs: deepCopy<ExplorerAPI[]>(this.explorerAPIs)
     });
-    return await verifier.verify(stepCallback);
+    const verificationStatus = await verifier.verify(stepCallback);
+    this.publicKey = verifier.getIssuingAddress();
+    return verificationStatus;
   }
 
   _setOptions (options): void {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ export { BLOCKCHAINS, STEPS, SUB_STEPS, CERTIFICATE_VERSIONS, VERIFICATION_STATU
 export { getSupportedLanguages } from './domain/i18n/useCases';
 export { SignatureImage } from './models';
 export { retrieveBlockcertsVersion } from './parsers';
+export { IFinalVerificationStatus } from './verifier';
 
 export enum SupportedChains {
   Bitcoin = 'bitcoin',

--- a/src/parsers/parseV2.ts
+++ b/src/parsers/parseV2.ts
@@ -20,7 +20,6 @@ export default function parseV2 (certificateJson): BlockcertsV2 {
   const chain: IBlockchainObject = domain.certificates.getChain(issuerKey, certificateJson.signature);
   const issuedOn = certificateJson.issuedOn;
   const metadataJson = certificateJson.metadataJson;
-  const publicKey = recipientProfile.publicKey;
   const recipientFullName = recipientProfile.name;
   const revocationKey = null;
   const sealImage = issuer.image;
@@ -36,7 +35,6 @@ export default function parseV2 (certificateJson): BlockcertsV2 {
     issuer,
     metadataJson,
     name,
-    publicKey,
     receipt,
     recipientFullName,
     recordLink: id,

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -36,9 +36,9 @@ export default class Verifier {
   public transactionId: string;
   public documentToVerify: Blockcerts; // TODO: confirm this
   public explorerAPIs: ExplorerAPI[];
+  public txData: TransactionData;
   private readonly _stepsStatuses: any[]; // TODO: define stepStatus interface
   private localHash: string;
-  private txData: TransactionData;
   private issuerPublicKeyList: IssuerPublicKeyList;
 
   constructor (
@@ -75,6 +75,13 @@ export default class Verifier {
     // Final verification result
     // Init status as success, we will update the final status at the end
     this._stepsStatuses = [];
+  }
+
+  getIssuingAddress (): string {
+    if (!this.txData) {
+      console.error('Trying to access issuing address when txData not available yet. Did you run the `verify` method yet?');
+    }
+    return this.txData?.issuingAddress;
   }
 
   async verify (stepCallback: IVerificationStepCallbackFn = () => {}): Promise<IFinalVerificationStatus> {

--- a/test/application/certificate/certificate-v2.test.ts
+++ b/test/application/certificate/certificate-v2.test.ts
@@ -1,6 +1,6 @@
 import { BLOCKCHAINS, Certificate, CERTIFICATE_VERSIONS } from '../../../src';
 import mainnetMapAssertion from '../domain/certificates/useCases/assertions/mainnetMapAssertion';
-import fixture from '../../fixtures/v2/mainnet-valid-2.0';
+import fixture from '../../fixtures/v2/mainnet-valid-2.0.json';
 
 describe('Certificate entity test suite', function () {
   describe('constructor method', function () {
@@ -32,10 +32,6 @@ describe('Certificate entity test suite', function () {
         expect(certificate.description).toEqual(fixture.badge.description);
       });
 
-      it('should set expires of the certificate object', function () {
-        expect(certificate.expires).toEqual(fixture.expires);
-      });
-
       it('should set id of the certificate object', function () {
         expect(certificate.id).toEqual(fixture.id);
       });
@@ -54,10 +50,6 @@ describe('Certificate entity test suite', function () {
 
       it('should set name to the certificate object', function () {
         expect(certificate.name).toEqual(fixture.badge.name);
-      });
-
-      it('should set publicKey of the certificate object', function () {
-        expect(certificate.publicKey).toEqual(fixture.recipientProfile.publicKey);
       });
 
       it('should set receipt of the certificate object', function () {
@@ -89,20 +81,18 @@ describe('Certificate entity test suite', function () {
         expect(certificate.signatureImage.length).toEqual(1);
       });
 
-      it('should set subtitle to the certificate object', function () {
-        expect(certificate.subtitle).toEqual(fixture.badge.subtitle);
-      });
-
       it('should set transactionId to the certificate object', function () {
         expect(certificate.transactionId).toEqual(fixture.signature.anchors[0].sourceId);
       });
 
       it('should set rawTransactionLink to the certificate object', function () {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         const rawTransactionLinkAssertion = `https://blockchain.info/rawtx/${fixture.signature.anchors[0].sourceId}`;
         expect(certificate.rawTransactionLink).toEqual(rawTransactionLinkAssertion);
       });
 
       it('should set transactionLink to the certificate object', function () {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         const transactionLinkAssertion = `https://blockchain.info/tx/${fixture.signature.anchors[0].sourceId}`;
         expect(certificate.transactionLink).toEqual(transactionLinkAssertion);
       });

--- a/test/application/certificate/verify-v2.test.ts
+++ b/test/application/certificate/verify-v2.test.ts
@@ -50,6 +50,11 @@ describe('Certificate test suite', function () {
           const finalStep = await certificate.verify();
           expect(finalStep).toEqual(expectedFinalStep);
         });
+
+        it('should set the publicKey property on the certificate', async function () {
+          await certificate.verify();
+          expect(certificate.publicKey).toBe('1AwdUWQzJgfDDjeKtpPzMfYMHejFBrxZfo');
+        });
       });
 
       describe('when the certificate is invalid', function () {

--- a/test/application/certificate/verify-v3.test.ts
+++ b/test/application/certificate/verify-v3.test.ts
@@ -48,6 +48,11 @@ describe('Certificate test suite', function () {
           const finalStep = await certificate.verify();
           expect(finalStep).toEqual(expectedFinalStep);
         });
+
+        it('should set the publicKey property on the certificate', async function () {
+          await certificate.verify();
+          expect(certificate.publicKey).toBe('0x7e30a37763e6ba1ffede1750bbefb4c60b17a1b3');
+        });
       });
 
       describe('when the certificate has been tampered with', function () {

--- a/test/application/parsers/parser-v2.test.ts
+++ b/test/application/parsers/parser-v2.test.ts
@@ -57,10 +57,6 @@ describe('Parser test suite', function () {
       expect(parsedCertificate.name).toEqual(fixture.badge.name);
     });
 
-    it('should set the publicKey of the certificate object', function () {
-      expect(parsedCertificate.publicKey).toEqual(fixture.recipientProfile.publicKey);
-    });
-
     it('should set the receipt of the certificate object', function () {
       expect(parsedCertificate.receipt).toEqual(fixture.signature);
     });


### PR DESCRIPTION
We were retrieving the data from the certificate, but if the data was not correct it wouldn't match the displayed public key, or it could be spoofed.

So now we are using the only source of truth, the issuing address. But that requires fetching the `txData`, and makes it then available somewhat after the verification process. 

I didn't want to necessarily inject the certificate into the verifier to update as soon as we were getting the txData, to avoid a circular dependency, neither did I feel right to pass a callback to pass the information up. But I am open to suggestions.