### PR TITLE
chore(CI): ensure semantic release has access to expected packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ after_script:
   - npm run test:coverage
   - npm run test:coverage:report
 after_success:
+  # to make the build work through rollup with DID logic (https://github.com/blockchain-certificates/cert-verifier-js/pull/1257)
+  # we are aliasing readable-stream to https://github.com/exogee-technology/readable-stream
+  # however this breaks semantic release because the shape of the export is different
+  # so we install the regular version of readable stream to enable expected use by semantic release
+  # it is an inelegant patch but it's a quick solution to the problem and is acceptable as it is the last step of the CI
+  - npm uninstall readable-stream
+  - npm install readable-stream
   - npm run semantic-release
 after_failure:
   - cat  /home/travis/.npm/_logs/2021-02-08T14_3*-debug.log

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'scope-empty': [2, 'never'],
-    'scope-case': [2, 'always', ['pascal-case', 'camel-case', 'lower-case']],
+    'scope-case': [2, 'always', ['pascal-case', 'camel-case', 'lower-case', 'upper-case']],
     'header-max-length': [0, 'always', 96]
   }
 };


### PR DESCRIPTION
Fixing semantic release by uninstalling the aliased package used for the build and reinstalling the expected readable-stream package. Yes it is a lazy fix