### PR TITLE
ensures buffer is available when converting into ETH address

### DIFF
--- a/src/helpers/issuingAddress.ts
+++ b/src/helpers/issuingAddress.ts
@@ -1,6 +1,7 @@
 import * as bitcoin from 'bitcoinjs-lib';
 import { ec } from 'elliptic';
 import { keccak256 } from 'js-sha3';
+import { Buffer as BufferPolyfill } from 'buffer';
 import type { IBlockchainObject } from '../constants/blockchains';
 
 export function computeBitcoinAddressFromPublicKey (publicKey: Buffer, chain: IBlockchainObject): string {
@@ -18,7 +19,8 @@ export function computeEthereumAddressFromPublicKey (publicKey: Buffer, chain: I
   // Convert to uncompressed format
   const publicKeyUncompressed = key.getPublic().encode('hex').slice(2);
 
+  const buffer = typeof Buffer === 'undefined' ? BufferPolyfill : Buffer;
   // Now apply keccak
-  const address: string = keccak256(Buffer.from(publicKeyUncompressed, 'hex')).slice(64 - 40);
+  const address: string = keccak256(buffer.from(publicKeyUncompressed, 'hex')).slice(64 - 40);
   return `0x${address.toString()}`;
 }

--- a/test/application/inspectors/did/deriveIssuingAddressFromPublicKey.test.ts
+++ b/test/application/inspectors/did/deriveIssuingAddressFromPublicKey.test.ts
@@ -1,0 +1,62 @@
+import type { IDidDocumentPublicKey } from '@decentralized-identity/did-common-typescript';
+import didDocument from '../../../fixtures/did/did:ion:EiA_Z6LQILbB2zj_eVrqfQ2xDm4HNqeJUw5Kj2Z7bFOOeQ.json';
+import deriveIssuingAddressFromPublicKey from '../../../../src/inspectors/did/deriveIssuingAddressFromPublicKey';
+import { BLOCKCHAINS } from '../../../../src';
+
+describe('deriveIssuingAddressFromPublicKey test suite', function () {
+  let publicKey: IDidDocumentPublicKey;
+
+  beforeEach(function () {
+    publicKey = Object.assign({}, didDocument.verificationMethod[0]);
+  });
+
+  describe('given the argument chain was Bitcoin', function () {
+    it('should return the address of Bitcoin Mainnet', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.bitcoin);
+      expect(address).toBe('127ZSsk5cWiubyDBkocJdW9dFYLN5N1jHF');
+    });
+  });
+
+  describe('given the argument chain was Mocknet', function () {
+    it('should return the address of Bitcoin Mocknet', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.mocknet);
+      expect(address).toBe('127ZSsk5cWiubyDBkocJdW9dFYLN5N1jHF');
+    });
+  });
+
+  describe('given the argument chain was Testnet', function () {
+    it('should return the address of Bitcoin Testnet', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.testnet);
+      expect(address).toBe('mgdWjvq4RYAAP5goUNagTRMx7Xw534S5am');
+    });
+  });
+
+  describe('given the argument chain was Ethmain', function () {
+    it('should return the address of Ethereum', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.ethmain);
+      expect(address).toBe('0x40cf9b7db6fcc742ad0a76b8588c7f8de2b54a60');
+    });
+  });
+
+  describe('given the argument chain was Ethropst', function () {
+    it('should return the address of Ethereum', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.ethropst);
+      expect(address).toBe('0x40cf9b7db6fcc742ad0a76b8588c7f8de2b54a60');
+    });
+  });
+
+  describe('given the argument chain was Ethrinkeby', function () {
+    it('should return the address of Ethereum', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.ethrinkeby);
+      expect(address).toBe('0x40cf9b7db6fcc742ad0a76b8588c7f8de2b54a60');
+    });
+  });
+
+  describe('given the argument chain was Regtest (Unsupported)', function () {
+    it('should throw', function () {
+      expect(() => {
+        deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.regtest);
+      }).toThrow('Issuer identity mismatch - Unsupported blockchain for DID verification');
+    });
+  });
+});


### PR DESCRIPTION
### Summary

refs [this forum page](https://community.blockcerts.org/t/v3-verifier-i-got-an-error-buffer-is-not-defined/3226)

>I tried to verify the generated VC on my local verifier and https://www.blockcerts.org/.
>I got an error “Buffer is not defined” like this.

### Other Information

I tested manually and confirmed that it was able to verify processes in my local environment, using [this VC](https://gist.github.com/koshilife/298217a894e47448a5e36168d26560ef).

![Screen Shot 2022-06-21 at 20 12 38](https://user-images.githubusercontent.com/583336/174788888-d28d6a7b-c7d6-42be-9f08-0cf356b2dcff.png)

