### PR TITLE
Support verifying VCs on the Goerli and the Sepolia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@babel/runtime-corejs3": "^7.8.7",
-        "@blockcerts/explorer-lookup": "^1.2.1",
+        "@blockcerts/explorer-lookup": "^1.3.0",
         "@blockcerts/hashlink-verifier": "^1.3.0",
         "@blockcerts/schemas": "^3.2.1",
         "@bloomprotocol/ecdsa-secp256k1-signature-2019": "^0.1.3",
@@ -24,7 +24,7 @@
         "@transmute/did-key-secp256k1": "^0.3.0-unstable.8",
         "@transmute/ed25519-key-pair": "^0.7.0-unstable.63",
         "@trust/keyto": "^1.0.1",
-        "@vaultie/lds-merkle-proof-2019": "0.0.8",
+        "@vaultie/lds-merkle-proof-2019": "github:vaultie/lds-merkle-proof-2019#e4b7197d6759d1ef882e8a06f61ba07ccc20d819",
         "base58-universal": "github:lemoustachiste/base58-universal#fix/hoisting-error-alphabet",
         "bigi": "^1.4.2",
         "bitcoinjs-lib": "^5.2.0",
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/@blockcerts/explorer-lookup": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@blockcerts/explorer-lookup/-/explorer-lookup-1.2.1.tgz",
-      "integrity": "sha512-JASXJhMIExXgdLurJHkntskjpSQNPkY6dvxaV0t3ZrXhKYlBI7rZ2g4+UIodlbFeZKH4ueS5phdy2xviJPJJqg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@blockcerts/explorer-lookup/-/explorer-lookup-1.3.0.tgz",
+      "integrity": "sha512-V4nYyxHdrWieaB4zxYbzF7wZJvU869hCl1rzpkchA24QgF3ccFORlhT9+fo7dDTXgr/uHX1i4AX+yGldEOsQow==",
       "dependencies": {
         "xmlhttprequest": "^1.8.0"
       }
@@ -5314,9 +5314,10 @@
       }
     },
     "node_modules/@vaultie/lds-merkle-proof-2019": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@vaultie/lds-merkle-proof-2019/-/lds-merkle-proof-2019-0.0.8.tgz",
-      "integrity": "sha512-Tn+M9Vbj7Ie0ab4jqjWWBXZ4RDWn+cHWf+drSgbQgwtEs4h0hGvaNTEzSNcChOndC/XxzetmfK+XqVryfv2f7w==",
+      "version": "0.0.7",
+      "resolved": "git+ssh://git@github.com/vaultie/lds-merkle-proof-2019.git#e4b7197d6759d1ef882e8a06f61ba07ccc20d819",
+      "integrity": "sha512-Blo+hk5TKLcL2u+bZAava/sEMxrE/1n86SVxTnS6f1okW1rZCmNoTf8VxvQ3zPdN0Y/sIqxhhBVMbbKqzShsZw==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.10.2",
         "cbor": "^5.0.1",
@@ -26587,9 +26588,9 @@
       "integrity": "sha512-R524tD5VwOt3QRHr7N518nqTVR/HKgfWL4LypekcGuNQN8R4PWScvuRcRzrY39A28kLztMv+TJdiKuMNbkU1ug=="
     },
     "@blockcerts/explorer-lookup": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@blockcerts/explorer-lookup/-/explorer-lookup-1.2.1.tgz",
-      "integrity": "sha512-JASXJhMIExXgdLurJHkntskjpSQNPkY6dvxaV0t3ZrXhKYlBI7rZ2g4+UIodlbFeZKH4ueS5phdy2xviJPJJqg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@blockcerts/explorer-lookup/-/explorer-lookup-1.3.0.tgz",
+      "integrity": "sha512-V4nYyxHdrWieaB4zxYbzF7wZJvU869hCl1rzpkchA24QgF3ccFORlhT9+fo7dDTXgr/uHX1i4AX+yGldEOsQow==",
       "requires": {
         "xmlhttprequest": "^1.8.0"
       }
@@ -29351,9 +29352,9 @@
       }
     },
     "@vaultie/lds-merkle-proof-2019": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@vaultie/lds-merkle-proof-2019/-/lds-merkle-proof-2019-0.0.8.tgz",
-      "integrity": "sha512-Tn+M9Vbj7Ie0ab4jqjWWBXZ4RDWn+cHWf+drSgbQgwtEs4h0hGvaNTEzSNcChOndC/XxzetmfK+XqVryfv2f7w==",
+      "version": "git+ssh://git@github.com/vaultie/lds-merkle-proof-2019.git#e4b7197d6759d1ef882e8a06f61ba07ccc20d819",
+      "integrity": "sha512-Blo+hk5TKLcL2u+bZAava/sEMxrE/1n86SVxTnS6f1okW1rZCmNoTf8VxvQ3zPdN0Y/sIqxhhBVMbbKqzShsZw==",
+      "from": "@vaultie/lds-merkle-proof-2019@github:vaultie/lds-merkle-proof-2019#e4b7197d6759d1ef882e8a06f61ba07ccc20d819",
       "requires": {
         "ajv": "^6.10.2",
         "cbor": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@babel/runtime-corejs3": "^7.8.7",
-    "@blockcerts/explorer-lookup": "^1.2.1",
+    "@blockcerts/explorer-lookup": "^1.3.0",
     "@blockcerts/hashlink-verifier": "^1.3.0",
     "@blockcerts/schemas": "^3.2.1",
     "@bloomprotocol/ecdsa-secp256k1-signature-2019": "^0.1.3",
@@ -68,7 +68,7 @@
     "@transmute/did-key-secp256k1": "^0.3.0-unstable.8",
     "@transmute/ed25519-key-pair": "^0.7.0-unstable.63",
     "@trust/keyto": "^1.0.1",
-    "@vaultie/lds-merkle-proof-2019": "0.0.8",
+    "@vaultie/lds-merkle-proof-2019": "github:vaultie/lds-merkle-proof-2019#e4b7197d6759d1ef882e8a06f61ba07ccc20d819",
     "base58-universal": "github:lemoustachiste/base58-universal#fix/hoisting-error-alphabet",
     "bigi": "^1.4.2",
     "bitcoinjs-lib": "^5.2.0",

--- a/src/constants/blockchains.ts
+++ b/src/constants/blockchains.ts
@@ -5,6 +5,8 @@ export enum SupportedChains {
   Ethmain = 'ethmain',
   Ethropst = 'ethropst',
   Ethrinkeby = 'ethrinkeby',
+  Ethgoerli = 'ethgoerli',
+  Ethsepolia = 'ethsepolia',
   Mocknet = 'mocknet',
   Regtest = 'regtest',
   Testnet = 'testnet'
@@ -59,6 +61,24 @@ const BLOCKCHAINS: {[chain in SupportedChains]: IBlockchainObject} = {
     transactionTemplates: {
       full: `https://rinkeby.etherscan.io/tx/${TRANSACTION_ID_PLACEHOLDER}`,
       raw: `https://rinkeby.etherscan.io/getRawTx?tx=${TRANSACTION_ID_PLACEHOLDER}`
+    }
+  },
+  [SupportedChains.Ethgoerli]: {
+    code: SupportedChains.Ethgoerli,
+    name: 'Ethereum Testnet',
+    signatureValue: 'ethereumGoerli',
+    transactionTemplates: {
+      full: `https://goerli.etherscan.io/tx/${TRANSACTION_ID_PLACEHOLDER}`,
+      raw: `https://goerli.etherscan.io/getRawTx?tx=${TRANSACTION_ID_PLACEHOLDER}`
+    }
+  },
+  [SupportedChains.Ethsepolia]: {
+    code: SupportedChains.Ethsepolia,
+    name: 'Ethereum Testnet',
+    signatureValue: 'ethereumSepolia',
+    transactionTemplates: {
+      full: `https://sepolia.etherscan.io/tx/${TRANSACTION_ID_PLACEHOLDER}`,
+      raw: `https://sepolia.etherscan.io/getRawTx?tx=${TRANSACTION_ID_PLACEHOLDER}`
     }
   },
   [SupportedChains.Mocknet]: {

--- a/src/inspectors/did/deriveIssuingAddressFromPublicKey.ts
+++ b/src/inspectors/did/deriveIssuingAddressFromPublicKey.ts
@@ -21,6 +21,8 @@ export default function deriveIssuingAddressFromPublicKey (verificationMethodPub
     case SupportedChains.Ethmain:
     case SupportedChains.Ethropst:
     case SupportedChains.Ethrinkeby:
+    case SupportedChains.Ethgoerli:
+    case SupportedChains.Ethsepolia:
       address = computeEthereumAddressFromPublicKey(publicKey, chain);
       break;
 

--- a/test/application/domain/certificates/useCases/getChain.test.ts
+++ b/test/application/domain/certificates/useCases/getChain.test.ts
@@ -117,6 +117,32 @@ describe('domain certificates get chain use case test suite', function () {
           expect(result).toEqual(chainAssertion);
         });
       });
+
+      describe('and the network is goerli', function () {
+        it('should return ethereum goerli value', function () {
+          const fixtureSignature = {
+            anchors: [
+              'blink:eth:goerli:0xfaea9061b06ff532d96ad91bab89fdfab900ae7d4524161431dc88318216435a'
+            ]
+          };
+          const result = domain.certificates.getChain(fixtureAddress, fixtureSignature);
+          const chainAssertion = BLOCKCHAINS.ethgoerli;
+          expect(result).toEqual(chainAssertion);
+        });
+      });
+
+      describe('and the network is sepolia', function () {
+        it('should return ethereum sepolia value', function () {
+          const fixtureSignature = {
+            anchors: [
+              'blink:eth:sepolia:0xfaea9061b06ff532d96ad91bab89fdfab900ae7d4524161431dc88318216435a'
+            ]
+          };
+          const result = domain.certificates.getChain(fixtureAddress, fixtureSignature);
+          const chainAssertion = BLOCKCHAINS.ethsepolia;
+          expect(result).toEqual(chainAssertion);
+        });
+      });
     });
   });
 

--- a/test/application/inspectors/did/deriveIssuingAddressFromPublicKey.test.ts
+++ b/test/application/inspectors/did/deriveIssuingAddressFromPublicKey.test.ts
@@ -52,6 +52,20 @@ describe('deriveIssuingAddressFromPublicKey test suite', function () {
     });
   });
 
+  describe('given the argument chain was Ethgoerli', function () {
+    it('should return the address of Ethereum', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.ethgoerli);
+      expect(address).toBe('0x40cf9b7db6fcc742ad0a76b8588c7f8de2b54a60');
+    });
+  });
+
+  describe('given the argument chain was Ethsepolia', function () {
+    it('should return the address of Ethereum', function () {
+      const address = deriveIssuingAddressFromPublicKey(publicKey, BLOCKCHAINS.ethsepolia);
+      expect(address).toBe('0x40cf9b7db6fcc742ad0a76b8588c7f8de2b54a60');
+    });
+  });
+
   describe('given the argument chain was Regtest (Unsupported)', function () {
     it('should throw', function () {
       expect(() => {


### PR DESCRIPTION
Hi maintainers,

This PR is to allow using Ethereum testnets, the Goerli and the Sepolia.
We have discussed this on [this forum page](https://community.blockcerts.org/t/ethereum-announced-the-testnet-ropsten-would-be-closed-in-q4-2022/3227).
Could you check this?

# Test

After set to use temporary npm packages ([tmp-lds-merkle-proof-2019](https://www.npmjs.com/package/koshilife-lds-merkle-proof-2019) and [tmp-explorer-lookup](https://www.npmjs.com/package/koshilife-explorer-lookup)) and built this in my local environment, And then I confirmed that the following VCs could been verified.

- Bitcoin
  - mainnet [ref](https://github.com/blockchain-certificates/cert-verifier-js/blob/master/test/fixtures/v2/mainnet-valid-2.0.json)
  - testnet [ref](https://github.com/blockchain-certificates/cert-verifier-js/blob/master/test/fixtures/v2/testnet-valid-2.0.json)
- Ethereum 
  - mainnet [ref](https://github.com/blockchain-certificates/cert-verifier-js/blob/master/test/fixtures/v2/ethereum-main-valid-2.0.json)
  - Ropsten [ref](https://github.com/blockchain-certificates/cert-verifier-js/blob/master/test/fixtures/v3/blockcerts-3.0-beta-did-ethereum-ropsten.json)

<details>
<summary>Goerli:</summary>

```json
{"@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/blockcerts/v3"], "id": "foobar#1", "type": ["VerifiableCredential", "BlockcertsCredential"], "issuer": {"id": "did:web:s.koshi.life", "name": "Example University"}, "issuanceDate": "2010-01-01T19:33:24Z", "nonce": "11", "credentialSubject": {"id": "did:example:1"}, "proof": {"type": "MerkleProof2019", "created": "2022-07-02T02:27:25.065544", "proofValue": "z7veGu1qoKR3AS5Aw3kgwhoA5zyobRRDYzRpVPiKTRxHYXsTzTR9MhdApxiEWJX18JQb3ZoGuTRALKjHYazdRtgMDd2Zww7PZvUczircteyDJdHJEczBD7m2kLQGPTRS2xPQXL5hgUaaF5sNkcSMQT2Dgo5RjwjG2vQ4KtC7T2rayZF6jaMaEXMyJpsxzV6Tm7dKsrmjyA8nWHnPHRCyR1hTGEjrZgJeC5YigorFbjmcpRi2vc3za3SaE6MVnMggqg5TTDo7EwgXVEE694gtQWhB8TwKj4ajnTwnNi6et2nSpGxrxh8mKx", "proofPurpose": "assertionMethod", "verificationMethod": "did:web:s.koshi.life#key-1"}}
```
</details>

<details>
<summary>Sepolia:</summary>

```json
{"@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/blockcerts/v3"], "id": "foobar#1", "type": ["VerifiableCredential", "BlockcertsCredential"], "issuer": {"id": "did:web:s.koshi.life", "name": "Example University"}, "issuanceDate": "2010-01-01T19:33:24Z", "nonce": "11", "credentialSubject": {"id": "did:example:1"}, "proof": {"type": "MerkleProof2019", "created": "2022-07-02T02:25:43.737850", "proofValue": "znKD4YGVqA8textxhpfA5ZiYaHbJ2QkTMSGmZNfdnQxz66EMw89dL4hJhjBH1Vrbc6bU7JsfkXLuyCiwisAEub3NiVMyEkRBDhxGX7iEirvLvYc3uGiNhVhRGnaK6aZSRnJsK5D7itDE5hrCLUQyngKdvfWn5Qdd8hHcG5wXmuaUZcQyctZbrvwBwsx6rHtaKMmW6EzpL7CLY84uZm9g2ZGev8MpV4xWCfk79MQsoKcrCCDu9Kg2QxqYakpiyFUDxoL6wsGnktrBSh6jNYZLxGRPSYssF5P664Ko58Q9vjPfcd5ADApkq15cMmv", "proofPurpose": "assertionMethod", "verificationMethod": "did:web:s.koshi.life#key-1"}}
```
</details>

# Tasks

If you approve this, I think we need to do the below tasks.

- https://github.com/vaultie/lds-merkle-proof-2019/pull/17
- https://github.com/vaultie/lds-merkle-proof-2019/pull/18
  - [ ] ~merge and release a new package~ we can't control the release, so I worked around to point the commit.
- https://github.com/blockchain-certificates/explorer-lookup/pull/263
  - [x] merge and release a new package
- [x] update the dependencies to use the new packages, `lds-merkle-proof-2019` and `explorer-lookup`

