### PR TITLE
test(Ethereum): fix 404 on issuer profile

### DIFF
--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -46,6 +46,7 @@ export default async function parseJSON (certificateJson: Blockcerts): Promise<P
     parsedCertificate.isFormatValid = true;
     return parsedCertificate;
   } catch (error) {
+    console.error(error);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return {
       isFormatValid: false,

--- a/test/e2e/verifier/ethereum-main-invalid-merkle-root.test.ts
+++ b/test/e2e/verifier/ethereum-main-invalid-merkle-root.test.ts
@@ -2,6 +2,7 @@ import { Certificate, VERIFICATION_STATUSES } from '../../../src';
 import sinon from 'sinon';
 import FIXTURES from '../../fixtures';
 import domain from '../../../src/domain';
+import * as ExplorerLookup from '@blockcerts/explorer-lookup';
 
 describe('given the certificate is an ethereum main with an invalid merkle root', function () {
   let certificate;
@@ -14,6 +15,24 @@ describe('given the certificate is an ethereum main with an invalid merkle root'
       time: '2018-05-08T18:30:34.000Z',
       revokedAddresses: []
     });
+
+    sinon.stub(ExplorerLookup, 'request').withArgs({
+      url: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth.json?raw=true'
+    }).resolves(JSON.stringify({
+      '@context': [
+        'https://w3id.org/openbadges/v2',
+        'https://w3id.org/blockcerts/3.0'
+      ],
+      type: 'Profile',
+      id: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth.json?raw=true',
+      publicKey: [
+        {
+          id: 'ecdsa-koblitz-pubkey:0x3d995ef85a8d1bcbed78182ab225b9f88dc8937c',
+          created: '2018-01-01T21:10:10.615+00:00'
+        }
+      ]
+    }));
+
     certificate = new Certificate(FIXTURES.EthereumMainInvalidMerkleRoot);
     await certificate.init();
     result = await certificate.verify();

--- a/test/e2e/verifier/ethereum-main-revoked.test.ts
+++ b/test/e2e/verifier/ethereum-main-revoked.test.ts
@@ -2,7 +2,7 @@ import { Certificate, VERIFICATION_STATUSES } from '../../../src';
 import FIXTURES from '../../fixtures';
 import domain from '../../../src/domain';
 import sinon from 'sinon';
-import etherscanApiWithKey from '../../data/etherscan-key';
+import * as ExplorerLookup from '@blockcerts/explorer-lookup';
 
 describe('given the certificate is a revoked ethereum main', function () {
   let certificate;
@@ -15,7 +15,33 @@ describe('given the certificate is a revoked ethereum main', function () {
       time: '2018-05-09T14:23:49.000Z',
       revokedAddresses: []
     });
-    certificate = new Certificate(FIXTURES.EthereumMainRevoked, { explorerAPIs: [etherscanApiWithKey] });
+    const requestStub = sinon.stub(ExplorerLookup, 'request');
+    requestStub.withArgs({
+      url: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth.json?raw=true'
+    }).resolves(JSON.stringify({
+      '@context': [
+        'https://w3id.org/openbadges/v2',
+        'https://w3id.org/blockcerts/3.0'
+      ],
+      type: 'Profile',
+      id: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth.json?raw=true',
+      publicKey: [
+        {
+          id: 'ecdsa-koblitz-pubkey:0x3d995ef85a8d1bcbed78182ab225b9f88dc8937c',
+          created: '2018-01-01T21:10:10.615+00:00'
+        }
+      ],
+      revocationList: 'https://www.blockcerts.org/samples/3.0/revocation-list-blockcerts.json'
+    }));
+    requestStub.withArgs({
+      url: 'https://www.blockcerts.org/samples/3.0/revocation-list-blockcerts.json?assertionId=urn%3Auuid%3A3bc1a96a-3501-46ed-8f75-49612bbac257'
+    }).resolves(JSON.stringify({
+      revokedAssertions: [{
+        id: 'urn:uuid:3bc1a96a-3501-46ed-8f75-49612bbac257',
+        revocationReason: 'Accidentally issued to Ethereum.'
+      }]
+    }));
+    certificate = new Certificate(FIXTURES.EthereumMainRevoked);
     await certificate.init();
     result = await certificate.verify();
   });

--- a/test/e2e/verifier/ethereum-main-v2-valid.test.ts
+++ b/test/e2e/verifier/ethereum-main-v2-valid.test.ts
@@ -2,7 +2,7 @@ import { Certificate, VERIFICATION_STATUSES } from '../../../src';
 import FIXTURES from '../../fixtures';
 import domain from '../../../src/domain';
 import sinon from 'sinon';
-import etherscanApiWithKey from '../../data/etherscan-key';
+import * as ExplorerLookup from '@blockcerts/explorer-lookup';
 
 describe('given the certificate is a valid ethereum main', function () {
   it('should verify successfully', async function () {
@@ -12,7 +12,23 @@ describe('given the certificate is a valid ethereum main', function () {
       time: '2018-06-01T20:47:55.000Z',
       revokedAddresses: []
     });
-    const certificate = new Certificate(FIXTURES.EthereumMainV2Valid, { explorerAPIs: [etherscanApiWithKey] });
+    sinon.stub(ExplorerLookup, 'request').withArgs({
+      url: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth-mainnet.json?raw=true'
+    }).resolves(JSON.stringify({
+      '@context': [
+        'https://w3id.org/openbadges/v2',
+        'https://w3id.org/blockcerts/3.0'
+      ],
+      type: 'Profile',
+      id: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth-mainnet.json?raw=true',
+      publicKey: [
+        {
+          id: 'ecdsa-koblitz-pubkey:0x3d995ef85a8d1bcbed78182ab225b9f88dc8937c',
+          created: '2018-01-01T21:10:10.615+00:00'
+        }
+      ]
+    }));
+    const certificate = new Certificate(FIXTURES.EthereumMainV2Valid);
     await certificate.init();
     const result = await certificate.verify();
     expect(result.status).toBe(VERIFICATION_STATUSES.SUCCESS);

--- a/test/e2e/verifier/ethereum-ropsten-v2-valid.test.ts
+++ b/test/e2e/verifier/ethereum-ropsten-v2-valid.test.ts
@@ -2,7 +2,7 @@ import { Certificate, VERIFICATION_STATUSES } from '../../../src';
 import FIXTURES from '../../fixtures';
 import domain from '../../../src/domain';
 import sinon from 'sinon';
-import etherscanApiWithKey from '../../data/etherscan-key';
+import * as ExplorerLookup from '@blockcerts/explorer-lookup';
 
 describe('given the certificate is a valid ethereum ropsten', function () {
   it('should verify successfully', async function () {
@@ -12,9 +12,26 @@ describe('given the certificate is a valid ethereum ropsten', function () {
       time: '2018-05-30T03:14:05.000Z',
       revokedAddresses: []
     });
-    const certificate = new Certificate(FIXTURES.EthereumRopstenV2Valid, { explorerAPIs: [etherscanApiWithKey] });
+    sinon.stub(ExplorerLookup, 'request').withArgs({
+      url: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth-case-sensitive.json?raw=true'
+    }).resolves(JSON.stringify({
+      '@context': [
+        'https://w3id.org/openbadges/v2',
+        'https://w3id.org/blockcerts/3.0'
+      ],
+      type: 'Profile',
+      id: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth-case-sensitive.json?raw=true',
+      publicKey: [
+        {
+          id: 'ecdsa-koblitz-pubkey:0x3d995ef85a8d1bcbed78182ab225b9f88dc8937c',
+          created: '2018-01-01T21:10:10.615+00:00'
+        }
+      ]
+    }));
+    const certificate = new Certificate(FIXTURES.EthereumRopstenV2Valid);
     await certificate.init();
     const result = await certificate.verify();
     expect(result.status).toBe(VERIFICATION_STATUSES.SUCCESS);
+    sinon.restore();
   });
 });

--- a/test/e2e/verifier/ethereum-tampered.test.ts
+++ b/test/e2e/verifier/ethereum-tampered.test.ts
@@ -2,7 +2,7 @@ import { Certificate, VERIFICATION_STATUSES } from '../../../src';
 import FIXTURES from '../../fixtures';
 import domain from '../../../src/domain';
 import sinon from 'sinon';
-import etherscanApiWithKey from '../../data/etherscan-key';
+import * as ExplorerLookup from '@blockcerts/explorer-lookup';
 
 describe('given the certificate is a tampered ethereum', function () {
   let certificate;
@@ -15,7 +15,23 @@ describe('given the certificate is a tampered ethereum', function () {
       time: '2018-05-08T18:30:34.000Z',
       revokedAddresses: []
     });
-    certificate = new Certificate(FIXTURES.EthereumTampered, { explorerAPIs: [etherscanApiWithKey] });
+    sinon.stub(ExplorerLookup, 'request').withArgs({
+      url: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth.json?raw=true'
+    }).resolves(JSON.stringify({
+      '@context': [
+        'https://w3id.org/openbadges/v2',
+        'https://w3id.org/blockcerts/3.0'
+      ],
+      type: 'Profile',
+      id: 'https://raw.githubusercontent.com/AnthonyRonning/https-github.com-labnol-files/master/issuer-eth.json?raw=true',
+      publicKey: [
+        {
+          id: 'ecdsa-koblitz-pubkey:0x3d995ef85a8d1bcbed78182ab225b9f88dc8937c',
+          created: '2018-01-01T21:10:10.615+00:00'
+        }
+      ]
+    }));
+    certificate = new Certificate(FIXTURES.EthereumTampered);
     await certificate.init();
     result = await certificate.verify();
   });


### PR DESCRIPTION
Distant issuer profile for these tests has been removed, so we stub the behavior as expected.