### PR TITLE
chore(CI): disable husky on semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "npm run lint:js && npm run lint:ts",
     "lint:js": "semistandard --verbose",
     "lint:ts": "eslint . --ext .ts",
-    "semantic-release": "semantic-release",
+    "semantic-release": "$HUSKY=0 semantic-release",
     "prepare": "husky install"
   },
   "publishConfig": {


### PR DESCRIPTION
disable husky error when pushing tags, as seen on https://app.travis-ci.com/github/blockchain-certificates/cert-verifier-js/builds/254664996