### PR TITLE
remove node-fetch as first level dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "karma-chrome-launcher": "^3.2.0",
         "karma-firefox-launcher": "^2.1.2",
         "karma-jasmine": "^5.1.0",
-        "node-fetch": "^2.6.13",
+        "node-fetch": "^2.6.7",
         "nodemon": "^2.0.7",
         "rimraf": "^3.0.2",
         "rollup": "^3.27.0",
@@ -11476,9 +11476,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "karma-chrome-launcher": "^3.2.0",
         "karma-firefox-launcher": "^2.1.2",
         "karma-jasmine": "^5.1.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.13",
         "nodemon": "^2.0.7",
         "rimraf": "^3.0.2",
         "rollup": "^3.27.0",
@@ -2306,26 +2306,6 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/@octokit/rest": {
@@ -10368,25 +10348,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsonld-checker/node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsonld-signatures": {
       "version": "9.3.1",
       "license": "BSD-3-Clause",
@@ -11515,12 +11476,22 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true,
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -16858,26 +16829,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/teeny-request/node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/teeny-request/node_modules/uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,6 @@
         "karma-chrome-launcher": "^3.2.0",
         "karma-firefox-launcher": "^2.1.2",
         "karma-jasmine": "^5.1.0",
-        "node-fetch": "^2.6.7",
         "nodemon": "^2.0.7",
         "rimraf": "^3.0.2",
         "rollup": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "postinstall": "rm -rf node_modules/jsonld-checker/node_modules/jsonld && rm -rf node_modules/@bloomprotocol/ecdsa-secp256k1-verification-key-2019/node_modules/base58-universal && rm -rf node_modules/ky-universal/node_modules/node-fetch",
     "dts:bundle": "dts-bundle-generator -o ./dist/index.d.ts --project tsconfig.json --no-banner src/index.ts",
-    "test": "jest --setupFilesAfterEnv=./test/setup.ts",
+    "test": "jest --setupFilesAfterEnv=./test/setup.ts --maxWorkers=1",
     "test:build": "npm run test:manual:node:server& npm run test:build:esm && npm run test:build:cjs && npm run test:build:node && npm run test:build:iife && kill -9 $(lsof -t -i:4000)",
     "test:build:node": "jest --testRegex \"/*(verifier-node.test.build.js)\" --silent",
     "test:build:cjs": "jest --testRegex \"/*(verifier.test.build.js)\" --silent",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "^5.1.0",
-    "node-fetch": "^2.6.13",
+    "node-fetch": "^2.6.7",
     "nodemon": "^2.0.7",
     "rimraf": "^3.0.2",
     "rollup": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "postinstall": "rm -rf node_modules/jsonld-checker/node_modules/jsonld && rm -rf node_modules/@bloomprotocol/ecdsa-secp256k1-verification-key-2019/node_modules/base58-universal && rm -rf node_modules/ky-universal/node_modules/node-fetch",
     "dts:bundle": "dts-bundle-generator -o ./dist/index.d.ts --project tsconfig.json --no-banner src/index.ts",
-    "test": "jest --setupFilesAfterEnv=./test/setup.ts --maxWorkers=1",
+    "test": "jest --setupFilesAfterEnv=./test/setup.ts",
     "test:build": "npm run test:manual:node:server& npm run test:build:esm && npm run test:build:cjs && npm run test:build:node && npm run test:build:iife && kill -9 $(lsof -t -i:4000)",
     "test:build:node": "jest --testRegex \"/*(verifier-node.test.build.js)\" --silent",
     "test:build:cjs": "jest --testRegex \"/*(verifier.test.build.js)\" --silent",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "^5.1.0",
-    "node-fetch": "^2.6.7",
     "nodemon": "^2.0.7",
     "rimraf": "^3.0.2",
     "rollup": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "^5.1.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.13",
     "nodemon": "^2.0.7",
     "rimraf": "^3.0.2",
     "rollup": "^3.27.0",

--- a/test/manual-testing/node/request.js
+++ b/test/manual-testing/node/request.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const http = require('node:http');
 const fixtures = require('../fixtures/fixtures');
 
 function prettyFormat (jsonObject) {
@@ -12,17 +12,27 @@ async function verify (blockcerts, version) {
 
   console.log('Now starting verification of', version, blockcerts.id);
 
-  const verificationStatus = await fetch('http://localhost:4000/verification', {
-    body: JSON.stringify({
-      blockcerts,
-      version
-    }),
+  const req = http.request('http://localhost:4000/verification', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' }
-  }).then((res) => res.json());
+  }, function (res) {
+    res.setEncoding('utf-8');
+    res.on('data', (data) => {
+      console.log(prettyFormat(JSON.parse(data)));
+      console.log(version, 'verification end');
+    });
+  });
 
-  console.log(prettyFormat(verificationStatus));
-  console.log(version, 'verification end');
+  req.write(JSON.stringify({
+    blockcerts,
+    version
+  }));
+
+  req.on('error', (e) => {
+    console.error(e);
+  });
+
+  req.end();
 }
 
 function verifyCerts () {


### PR DESCRIPTION
fix node-fetch vulnerability.

Cannot yet use v3 as some ESM conflict. See https://github.com/blockchain-certificates/cert-verifier-js/pull/1525 