### PR TITLE
Prioritize revocation over suspension

### DIFF
--- a/src/inspectors/checkRevocationStatusList2021.ts
+++ b/src/inspectors/checkRevocationStatusList2021.ts
@@ -44,6 +44,8 @@ export default async function checkRevocationStatusList2021 (credentialStatus: V
     credentialStatus = [credentialStatus];
   }
 
+  let triggeredSuspension = false;
+
   for (const status of credentialStatus) {
     const credentialIndex = parseInt(status.statusListIndex, 10);
     const revocationCredential: VerifiableCredential = await getRevocationCredential(status.statusListCredential);
@@ -58,8 +60,14 @@ export default async function checkRevocationStatusList2021 (credentialStatus: V
     const decodedList: RevocationList = await decodeList({ encodedList });
 
     if (decodedList.isRevoked(credentialIndex)) {
-      const statusText = status.statusPurpose === 'revocation' ? CREDENTIAL_STATUS_OPTIONS.REVOKED : CREDENTIAL_STATUS_OPTIONS.SUSPENDED;
-      throw new VerifierError(SUB_STEPS.checkRevokedStatus, domain.certificates.generateRevocationReason('', statusText));
+      if (status.statusPurpose === 'revocation') {
+        throw new VerifierError(SUB_STEPS.checkRevokedStatus, domain.certificates.generateRevocationReason('', CREDENTIAL_STATUS_OPTIONS.REVOKED));
+      }
+      triggeredSuspension = true;
     }
+  }
+
+  if (triggeredSuspension) {
+    throw new VerifierError(SUB_STEPS.checkRevokedStatus, domain.certificates.generateRevocationReason('', CREDENTIAL_STATUS_OPTIONS.SUSPENDED));
   }
 }

--- a/test/application/inspectors/checkRevocationStatusList2021.test.ts
+++ b/test/application/inspectors/checkRevocationStatusList2021.test.ts
@@ -112,4 +112,33 @@ describe('checkRevocationStatusList2021 inspector test suite', function () {
       }).rejects.toThrow(`No status list could be found at the specified URL for 'statusListCredential': ${notFoundListUrl}.`);
     });
   });
+
+  describe('when the certificate is both revoked and suspended', function () {
+    const revokedEntry = {
+      id: 'https://www.blockcerts.org/samples/3.0/status-list-2021.json#23547',
+      type: 'StatusList2021Entry',
+      statusPurpose: 'revocation',
+      statusListIndex: '23547',
+      statusListCredential: 'https://www.blockcerts.org/samples/3.0/status-list-2021.json'
+    };
+    const suspendedEntry = {
+      id: 'https://www.blockcerts.org/samples/3.0/status-list-2021-suspension.json#12354',
+      type: 'StatusList2021Entry',
+      statusPurpose: 'suspension',
+      statusListIndex: '12354',
+      statusListCredential: 'https://www.blockcerts.org/samples/3.0/status-list-2021-suspension.json'
+    };
+
+    it('should report revoked when the revocation entry comes first', async function () {
+      await expect(async () => {
+        await checkRevocationStatusList2021([revokedEntry, suspendedEntry]);
+      }).rejects.toThrow('This certificate has been revoked by the issuer.');
+    });
+
+    it('should report revoked when the suspension entry comes first', async function () {
+      await expect(async () => {
+        await checkRevocationStatusList2021([suspendedEntry, revokedEntry]);
+      }).rejects.toThrow('This certificate has been revoked by the issuer.');
+    });
+  });
 });


### PR DESCRIPTION
This pull request improves the logic for handling credentials that may be both revoked and suspended in the `checkRevocationStatusList2021` inspector, ensuring that revocation takes precedence over suspension. It also adds new tests to verify this behavior.

**Revocation and Suspension Handling:**

* Updated `checkRevocationStatusList2021` in `src/inspectors/checkRevocationStatusList2021.ts` to ensure that if a credential is both revoked and suspended, the function will always throw a "revoked" error, regardless of the order of entries. Suspension is only reported if no revocation is found. [[1]](diffhunk://#diff-24d3e959a9fbb0aeaf76076176201c8f7a578ff1b0d569a448bdbebcb88aad92R47-R48) [[2]](diffhunk://#diff-24d3e959a9fbb0aeaf76076176201c8f7a578ff1b0d569a448bdbebcb88aad92L61-R72)

**Testing Improvements:**

* Added tests in `test/application/inspectors/checkRevocationStatusList2021.test.ts` to verify that "revoked" status is prioritized over "suspended", regardless of the order of entries in the input.